### PR TITLE
Add timeout feature for HTTP requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ name             | No          | Name in home app (default HTTP Sprinkler)
 icon             | No          | Icon displayed in Home app (possible values: 0, 1, 2, 3; default 0)
 onUrl            | Yes         | URL for turning on the sprinkler
 offUrl           | Yes         | URL for turning off the sprinkler
+timeout          | No          | HTTP request timeout in ms (default 5s)
 checkStatus      | No          | Indicator if status should be checked via the API (possible values: once, polling, no; default no)
 pollingInterval  | No          | If checkStatus is polling, the pollinginterval can be specified in milliseconds (default 3000 (3 seconds))
 statusUrl        | No          | URL to check the status via the API; required when checkStatus is once or polling
@@ -41,6 +42,7 @@ Configuration sample based on Domoticz JSON API:
                 "icon": 1,
                 "onUrl": "http://localhost:8080/json.htm?type=command&param=switchlight&idx=135&switchcmd=On",
                 "offUrl": "http://localhost:8080/json.htm?type=command&param=switchlight&idx=135&switchcmd=Off",
+                "timeout": 3000,
                 "checkStatus": "polling",
                 "pollingInterval": 5000,
                 "statusUrl": "http://localhost:8080/json.htm?type=devices&rid=135",

--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ function HttpSprinkler(log, config)
 	this.icon		= config["icon"]		|| 0
 	this.onUrl              = config["onUrl"];
 	this.offUrl             = config["offUrl"];
+	this.timeout            = config["timeout"]             || 5000;
 	this.checkStatus 	= config["checkStatus"]		|| "no";
 	this.pollingInterval    = config["pollingInterval"]   	|| 3000;
 	this.statusUrl          = config["statusUrl"];
@@ -109,6 +110,7 @@ HttpSprinkler.prototype =
 			url: url,
 			body: body,
 			method: method,
+			timeout: this.timeout,
 			rejectUnauthorized: false
 			},
 			function (error, response, responseBody) 


### PR DESCRIPTION
The plugin has been working great but I thought it would be a good idea to add a (customisable) timeout to the HTTP requests in order to make it more reliable in the sense that it should stop homebridge from hanging if it doesn't hear back.