### PR TITLE
Modify README & allow customisation of manufacturer, model and serial

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ sudo npm install -g homebridge-http-sprinkler
 | `name` | Name to appear in the Home app |
 | `onUrl` | URL to turn on sprinklers |
 | `offUrl` | URL to turn on sprinklers |
-| `icon` _(optional)_ | Icon to be shown in the Home app (`0`, `1`, `2`, `3`; `0` is default) |
-| `timeout` _(optional)_ | Time (in milliseconds) until the accessory will be marked as "Not Responding" if it is unreachable. (5000ms default) |
+| `icon` _(optional)_ | Icon to be shown in the Home app (`0`, `1`, `2`, `3`) (Default: `0`) |
+| `timeout` _(optional)_ | Time (in milliseconds) until the accessory will be marked as "Not Responding" if it is unreachable. (Default: `5000`) |
 | `httpMethod` _(optional)_ | Method for sending requests (`GET` is default) |
-| `checkStatus` _(optional)_ | Whether the status should be checked via the API (`once`, `polling`, `no`; `no` is default) |
+| `checkStatus` _(optional)_ | Whether the status should be checked via the API (`once`, `polling`, `no`) (Default: `no`) |
 | `pollingInterval` _(optional)_ | If `checkStatus` is set to `polling`, this is the time (in ms) betwwen status checks (3000ms default) |
 | `jsonPath` _(optional)_ | JSON Path where the status can be found; required when `checkStatus` is `once` or `polling` |
-| `onValue` _(optional)_ | Value for On when status is checked (`On` is default) |
-| `offValue` _(optional)_ | Value for Off when status is checked (`Off` is default) |
-| `useTimer` _(optional)_ | Indication if a timer can be used (possible values: `yes`, `no`; `no` is default) |
+| `onValue` _(optional)_ | Value for On when status is checked (Default: `On`) |
+| `offValue` _(optional)_ | Value for Off when status is checked (Default: `Off`) |
+| `useTimer` _(optional)_ | Indication if a timer can be used (`yes` or `no`) (Default: `no`) |
 | `defaultTime` _(optional)_ | Default time (in seconds) the timer should be set to if enabled |
 | `model` _(optional)_ | Appears under "Model" for your accessory in the Home app |
 | `serial` _(optional)_ | Appears under "Serial" for your accessory in the Home app |

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # homebridge-http-sprinkler
-A switch plugin for [homebridge](https://github.com/nfarina/homebridge) which integrates with HTTP(S) APIs.
 
-A plugin for sprinklers that can be controlled with an API.
+#### Homebridge plugin to control a web-based sprinkler via HTTP(S) APIs.
 
 ## Installation
 
@@ -73,4 +72,5 @@ sudo npm install -g homebridge-http-sprinkler
        "defaultTime": 900,
        "httpMethod": "GET"
      }
+]
 ```    

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # homebridge-http-sprinkler
-A switch plugin for homebridge (https://github.com/nfarina/homebridge) which integrates with HTTP(S) APIs.
+A switch plugin for [homebridge](https://github.com/nfarina/homebridge) which integrates with HTTP(S) APIs.
 
 A plugin for sprinklers that can be controlled with an API.
-
 
 # Installation
 
@@ -10,29 +9,45 @@ A plugin for sprinklers that can be controlled with an API.
 2. Install this plugin: `npm install -g homebridge-http-sprinkler`
 3. Update your `config.json` configuration file
 
-# Configuration
+## Structure & Interfacing
 
-Name             | Required    | Description
----------------- | ----------- | --------------------------------------------
-accessory        | Yes         | Has to be HttpSprinkler
-name             | No          | Name in home app (default HTTP Sprinkler)
-icon             | No          | Icon displayed in Home app (possible values: 0, 1, 2, 3; default 0)
-onUrl            | Yes         | URL for turning on the sprinkler
-offUrl           | Yes         | URL for turning off the sprinkler
-timeout          | No          | HTTP request timeout in ms (default 5s)
-checkStatus      | No          | Indicator if status should be checked via the API (possible values: once, polling, no; default no)
-pollingInterval  | No          | If checkStatus is polling, the pollinginterval can be specified in milliseconds (default 3000 (3 seconds))
-statusUrl        | No          | URL to check the status via the API; required when checkStatus is once or polling
-jsonPath         | No          | JSON Path where the status can be found; required when checkStatus is once or polling
-onValue          | No          | Value for On when status is checked (default On)
-offValue         | No          | Value for Off when status is checked (default Off)
-useTimer         | No          | Indication if a timer can be used (possible values: yes, no; default no)
-defaultTime      | No          | Default time in seconds the timer should be set to; can be changed in the settings page of the accessory, but resets every time homebridge is restarted; hence here the possibility to set a default
-httpMethod       | No          | Method for sending requests (default GET)
+| Key | Description |
+| --- | --- |
+| `accessory` | Must be `HttpSprinkler` |
+| `name` | Name to appear in the Home app |
+| `onUrl` | URL to turn on sprinklers |
+| `offUrl` | URL to turn on sprinklers |
+| `icon` _(optional)_ | Icon to be shown in the Home app (`0-3`, Default is `0`) |
+| `timeout` _(optional)_ | Time (in milliseconds) until the accessory will be marked as "Not Responding" if it is unreachable. (5000ms default) |
+| `httpMethod` _(optional)_ | Method for sending requests (`GET` is default) |
+| `checkStatus` _(optional)_ | Whether the status should be checked via the API (`once`, `polling`, `no`; `no` is default) |
+| `pollingInterval` _(optional)_ | If `checkStatus` is set to `polling`, this is the time (in ms) betwwen status checks (3000ms default) |
+| `jsonPath` _(optional)_ | JSON Path where the status can be found; required when `checkStatus` is `once` or `polling` |
+| `onValue` _(optional)_ | Value for On when status is checked (`On` is default) |
+| `offValue` _(optional)_ | Value for Off when status is checked (`Off` is default) |
+| `useTimer` _(optional)_ | Indication if a timer can be used (possible values: `yes`, `no`; `no` is default) |
+| `defaultTime` _(optional)_ | Default time (in seconds) the timer should be set to if enabled |
+| `model` _(optional)_ | Appears under "Model" for your accessory in the Home app |
+| `serial` _(optional)_ | Appears under "Serial" for your accessory in the Home app |
+| `manufacturer` _(optional)_ | Appears under "Manufacturer" for your accessory in the Home app |
 
+## Configuration Examples
 
+### Simple configuration
 
-Configuration sample based on Domoticz JSON API:
+```json
+ "accessories": [
+     {
+       "accessory": "HttpSprinkler",
+       "name": "HTTP Sprinkler",
+       "onUrl": "http://myurl.com/on",
+       "offUrl": "http://myurl.com/off",
+       "timeout": 3000
+     }
+]
+```
+
+### Sample based on Domoticz JSON API:
 
  ``` 
 "accessories": [ 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ sudo npm install -g homebridge-http-sprinkler
 | `name` | Name to appear in the Home app |
 | `onUrl` | URL to turn on sprinklers |
 | `offUrl` | URL to turn on sprinklers |
-| `icon` _(optional)_ | Icon to be shown in the Home app (`0-3`, Default is `0`) |
+| `icon` _(optional)_ | Icon to be shown in the Home app (`0`, `1`, `2`, `3`; `0` is default) |
 | `timeout` _(optional)_ | Time (in milliseconds) until the accessory will be marked as "Not Responding" if it is unreachable. (5000ms default) |
 | `httpMethod` _(optional)_ | Method for sending requests (`GET` is default) |
 | `checkStatus` _(optional)_ | Whether the status should be checked via the API (`once`, `polling`, `no`; `no` is default) |

--- a/README.md
+++ b/README.md
@@ -3,11 +3,16 @@ A switch plugin for [homebridge](https://github.com/nfarina/homebridge) which in
 
 A plugin for sprinklers that can be controlled with an API.
 
-# Installation
+## Installation
 
-1. Install homebridge using: `npm install -g homebridge`
-2. Install this plugin: `npm install -g homebridge-http-sprinkler`
-3. Update your `config.json` configuration file
+1. Install [homebridge](https://github.com/nfarina/homebridge#installation-details).
+
+2. Install this plugin: 
+```
+sudo npm install -g homebridge-http-sprinkler
+```
+
+3. Update your `config.json` file (See [below](#configuration-examples)).
 
 ## Structure & Interfacing
 
@@ -33,10 +38,10 @@ A plugin for sprinklers that can be controlled with an API.
 
 ## Configuration Examples
 
-### Simple configuration
+#### Simple configuration:
 
 ```json
- "accessories": [
+"accessories": [
      {
        "accessory": "HttpSprinkler",
        "name": "HTTP Sprinkler",
@@ -47,25 +52,25 @@ A plugin for sprinklers that can be controlled with an API.
 ]
 ```
 
-### Sample based on Domoticz JSON API:
+#### Sample based on Domoticz JSON API:
 
- ``` 
+ ```json
 "accessories": [ 
-        {
-                "accessory": "HttpSprinkler",
-                "name": "Sprinkler backyard",
-                "icon": 1,
-                "onUrl": "http://localhost:8080/json.htm?type=command&param=switchlight&idx=135&switchcmd=On",
-                "offUrl": "http://localhost:8080/json.htm?type=command&param=switchlight&idx=135&switchcmd=Off",
-                "timeout": 3000,
-                "checkStatus": "polling",
-                "pollingInterval": 5000,
-                "statusUrl": "http://localhost:8080/json.htm?type=devices&rid=135",
-                "jsonPath": "result[0].Status",
-                "onValue": "On",
-                "offValue": "Off",
-                "useTimer": "yes",
-                "defaultTime": 900,
-                "httpMethod": "GET"
-        }
+     {
+       "accessory": "HttpSprinkler",
+       "name": "Sprinkler backyard",
+       "icon": 1,
+       "onUrl": "http://localhost:8080/json.htm?type=command&param=switchlight&idx=135&switchcmd=On",
+       "offUrl": "http://localhost:8080/json.htm?type=command&param=switchlight&idx=135&switchcmd=Off",
+       "timeout": 3000,
+       "checkStatus": "polling",
+       "pollingInterval": 5000,
+       "statusUrl": "http://localhost:8080/json.htm?type=devices&rid=135",
+       "jsonPath": "result[0].Status",
+       "onValue": "On",
+       "offValue": "Off",
+       "useTimer": "yes",
+       "defaultTime": 900,
+       "httpMethod": "GET"
+     }
 ```    

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var request = require("request");
 var pollingtoevent = require('polling-to-event');
 
 
-module.exports = function(homebridge) 
+module.exports = function(homebridge)
 {
     Service = homebridge.hap.Service;
     Characteristic = homebridge.hap.Characteristic;
@@ -12,33 +12,40 @@ module.exports = function(homebridge)
 };
 
 
-function HttpSprinkler(log, config) 
+function HttpSprinkler(log, config)
 {
 	this.log = log;
-	
+
 	// Get config info
-	this.name		= config["name"]          	|| "HTTP Sprinkler";
-	this.icon		= config["icon"]		|| 0
+	this.name		            = config["name"]          	    || "HTTP Sprinkler";
+	this.icon		            = config["icon"]		            || 0
+
 	this.onUrl              = config["onUrl"];
 	this.offUrl             = config["offUrl"];
+  this.statusUrl          = config["statusUrl"];
+
+  this.httpMethod         = config["httpMethod"]   	      || "GET";
 	this.timeout            = config["timeout"]             || 5000;
-	this.checkStatus 	= config["checkStatus"]		|| "no";
 	this.pollingInterval    = config["pollingInterval"]   	|| 3000;
-	this.statusUrl          = config["statusUrl"];
-	this.jsonPath		= config["jsonPath"];
-	this.onValue		= config["onValue"]		|| "On";
-	this.offValue		= config["offValue"]		|| "Off";
-	this.useTimer		= config["useTimer"]		|| "no";
-	this.defaultTime	= config["defaultTime"]		|| 300;
-	this.httpMethod         = config["httpMethod"]   	|| "GET";
-	
+  this.checkStatus 	      = config["checkStatus"]		      || "no";
+
+	this.jsonPath		        = config["jsonPath"];
+	this.onValue		        = config["onValue"]		          || "On";
+	this.offValue		        = config["offValue"]		        || "Off";
+	this.useTimer		        = config["useTimer"]		        || "no";
+	this.defaultTime	      = config["defaultTime"]		      || 300;
+
+  this.manufacturer       = config["manufacturer"]        || "HTTP Manufacturer";
+  this.model              = config["model"]               || "homebridge-http-sprinkler";
+  this.serial             = config["serial"]              || "HTTP Serial Number";
+
 
 	//realtime polling info
 	this.statusOn = false;
 	var that = this;
 
 	// Status Polling
-	if (this.statusUrl && this.checkStatus === "polling") 
+	if (this.statusUrl && this.checkStatus === "polling")
 	{
 		var powerurl = this.statusUrl;
 		var statusemitter = pollingtoevent(function (done)
@@ -48,15 +55,15 @@ function HttpSprinkler(log, config)
 					if (error)
 					{
 						that.log('HTTP get status function failed: %s', error.message);
-						try 
+						try
 						{
 							done(new Error("Network failure that must not stop homebridge!"));
-						} catch (err) 
+						} catch (err)
 						{
 							that.log(err.message);
 						}
-					} 
-					else 
+					}
+					else
 					{
 						done(null, body);
 					}
@@ -64,31 +71,31 @@ function HttpSprinkler(log, config)
 		}, { interval: that.pollingInterval, eventName: "statuspoll" });
 
 
-		statusemitter.on("statuspoll", function (responseBody) 
+		statusemitter.on("statuspoll", function (responseBody)
 		{
-			if (that.onValue && that.offValue) 
+			if (that.onValue && that.offValue)
 			{
 				var json = JSON.parse(responseBody);
 				var status = eval("json." + that.jsonPath);
-				
+
 				if (status == that.onValue)
 				{
 					//that.log("State is currently: ON");
-					
+
 					that.valveService.getCharacteristic(Characteristic.Active)
 					.updateValue(1);
-		   
+
 					that.valveService.getCharacteristic(Characteristic.InUse)
 					.updateValue(1);
 				}
-				
+
 				if (status == that.offValue)
 				{
 					//that.log("State is currently: OFF");
-					
+
 					that.valveService.getCharacteristic(Characteristic.InUse)
 					.updateValue(0);
-					
+
 					that.valveService.getCharacteristic(Characteristic.Active)
 					.updateValue(0);
 				}
@@ -99,13 +106,13 @@ function HttpSprinkler(log, config)
 }
 
 
-HttpSprinkler.prototype = 
+HttpSprinkler.prototype =
 {
 
-	httpRequest: function (url, body, method, callback) 
+	httpRequest: function (url, body, method, callback)
 	{
 		var callbackMethod = callback;
-		
+
 		request({
 			url: url,
 			body: body,
@@ -113,23 +120,23 @@ HttpSprinkler.prototype =
 			timeout: this.timeout,
 			rejectUnauthorized: false
 			},
-			function (error, response, responseBody) 
+			function (error, response, responseBody)
 			{
-				if (callbackMethod) 
+				if (callbackMethod)
 				{
 					callbackMethod(error, response, responseBody)
 				}
-				else 
+				else
 				{
 					//this.log("callbackMethod not defined!");
 				}
 			})
 	},
-		
 
-	getPowerState: function (callback) 
+
+	getPowerState: function (callback)
 	{
-		if (!this.statusUrl || !this.jsonPath || !this.offValue) 
+		if (!this.statusUrl || !this.jsonPath || !this.offValue)
 		{
 			this.log("Ignoring request: Missing status properties in config.json.");
 			callback(new Error("No status url defined."));
@@ -137,144 +144,144 @@ HttpSprinkler.prototype =
 		}
 
 		var url = this.statusUrl;
-				
-		this.httpRequest(url, "", "GET", function (error, response, responseBody) 
+
+		this.httpRequest(url, "", "GET", function (error, response, responseBody)
 		{
-			if (error) 
+			if (error)
 			{
 				this.log('HTTP get status function failed: %s', error.message);
 				callback(error);
 			}
-			else 
+			else
 			{
 				var powerOn = false;
 				var json = JSON.parse(responseBody);
 				var status = eval("json." + this.jsonPath);
-				
-				if (status != this.offValue) 
+
+				if (status != this.offValue)
 				{
 					powerOn = true;
 				}
-				else 
+				else
 				{
 					powerOn = false;
 				}
-				
+
 				//this.log("status received from: " + url, "state is currently: ", powerOn.toString());
 				callback(null, powerOn);
 			}
 		}.bind(this));
 	},
-	
-	
-	setPowerState: function (powerOn, callback) 
+
+
+	setPowerState: function (powerOn, callback)
 	{
 		var url;
 		var body;
 		var inuse;
-		
+
 		var that = this;
-		
-		if (!this.onUrl || !this.offUrl) 
+
+		if (!this.onUrl || !this.offUrl)
 		{
 			this.log("Ignoring request: No power url defined.");
 			callback(new Error("No power url defined."));
 			return;
 		}
 
-		if (powerOn) 
+		if (powerOn)
 		{
 			url = this.onUrl;
 			inuse = 1;
 			this.log("Setting power state to on");
-		} 
-		else 
+		}
+		else
 		{
 			url = this.offUrl;
 			inuse = 0;
 			this.log("Setting power state to off");
 		}
-		
+
 		this.httpRequest(url, "", "GET", function (error, response, body)
 		{
 			if (error)
 			{
 				that.log("HTTP set status function failed %s", error.message);
-			} 
-		}.bind(this))	
-		
+			}
+		}.bind(this))
+
 		this.log("HTTP power function succeeded!");
 		this.valveService.getCharacteristic(Characteristic.InUse).updateValue(inuse);
 		callback();
-		
+
 	},
-	
-	
-	setPowerStatePolling: function (powerOn, callback) 
+
+
+	setPowerStatePolling: function (powerOn, callback)
 	{
 		var url;
 		var body;
 		var inuse;
-		
+
 		var that = this;
-		
-		if (!this.onUrl || !this.offUrl) 
+
+		if (!this.onUrl || !this.offUrl)
 		{
 			this.log("Ignoring request: No power url defined.");
 			callback(new Error("No power url defined."));
 			return;
 		}
 
-		if (powerOn) 
+		if (powerOn)
 		{
 			url = this.onUrl;
 			inuse = 1;
 			this.log("Setting power state to on");
-		} 
-		else 
+		}
+		else
 		{
 			url = this.offUrl;
 			inuse = 0;
 			this.log("Setting power state to off");
 		}
-		
+
 		this.httpRequest(url, "", "GET", function (error, response, body)
 		{
 			if (error)
 			{
 				that.log("HTTP set status function failed %s", error.message);
-			} 
-		}.bind(this))	
-		
+			}
+		}.bind(this))
+
 		// InUse characteristic is set with the polling mechanism
-		
+
 		callback();
-		
+
 	},
-	
-	
+
+
 	setDurationTime: function(data, callback)
 	{
 		console.log("Valve Time Duration Set to: " + data.newValue + " seconds")
-		
+
 		if(this.valveService.getCharacteristic(Characteristic.InUse).value)
 		{
 			this.valveService.getCharacteristic(Characteristic.RemainingDuration)
 				.updateValue(data.newValue);
-			
+
 			// clear any existing timer
 			clearTimeout(this.valveService.timer);
-			
-			this.valveService.timer = setTimeout( ()=> 
+
+			this.valveService.timer = setTimeout( ()=>
 			{
 				console.log("Valve Timer Expired. Shutting off Valve");
 				// use 'setvalue' when the timer ends so it triggers the .on('set'...) event
-				this.valveService.getCharacteristic(Characteristic.Active).setValue(0); 
-			}, (data.newValue *1000));	
+				this.valveService.getCharacteristic(Characteristic.Active).setValue(0);
+			}, (data.newValue *1000));
 		}
 	},
-	
-	
+
+
 	setRemainingTime: function(data, callback)
 	{
 		switch(data.newValue)
@@ -288,42 +295,42 @@ HttpSprinkler.prototype =
 			case 1:
 			{
 				var timer = this.valveService.getCharacteristic(Characteristic.SetDuration).value;
-					
+
 				this.valveService.getCharacteristic(Characteristic.RemainingDuration)
 					.updateValue(timer);
-									
+
 				console.log("Turning Valve "
 				    	+ this.name
 				    	+ " on with Timer set to: "
 				    	+ timer
-				    	+ " seconds");									
-					
-				this.valveService.timer = setTimeout( ()=> 
+				    	+ " seconds");
+
+				this.valveService.timer = setTimeout( ()=>
 				{
 					console.log("Valve Timer Expired. Shutting off Valve");
-			
+
 					// use 'setvalue' when the timer ends so it triggers the .on('set'...) event
-					this.valveService.getCharacteristic(Characteristic.Active).setValue(0); 
+					this.valveService.getCharacteristic(Characteristic.Active).setValue(0);
 				}, (timer *1000));
 				break;
 			}
 		}
 	},
-	
-	
+
+
 	getServices: function ()
 	{
 		var that = this;
-		
-		var informationService = new Service.AccessoryInformation();
 
-		informationService
-			.setCharacteristic(Characteristic.Manufacturer, "Sprinkler")
-			.setCharacteristic(Characteristic.Model, "Sprinkler Model")
-			.setCharacteristic(Characteristic.SerialNumber, "Sprinkler");
+    this.informationService = new Service.AccessoryInformation();
+
+		this.informationService
+			.setCharacteristic(Characteristic.Manufacturer, this.manufacturer)
+			.setCharacteristic(Characteristic.Model, this.model)
+			.setCharacteristic(Characteristic.SerialNumber, this.serial);
 
 		this.valveService = new Service.Valve(this.name);
-		
+
 		this.valveService.getCharacteristic(Characteristic.ValveType).updateValue(this.icon);
 		//this.valveService.addCharacteristic(Characteristic.IsConfigured);
 
@@ -334,56 +341,56 @@ HttpSprinkler.prototype =
 				this.log("Check status: once");
 				var powerState = this.getPowerState.bind(this)
 				var powerStateInt = 0
-				
+
 				this.valveService
 					.getCharacteristic(Characteristic.Active)
 					.on('set', this.setPowerState.bind(this))
 					.on('get', powerState);
-				
+
 				if (powerState) { powerStateInt = 1 }
 				else { powerStateInt = 0}
-				
+
 				this.valveService.getCharacteristic(Characteristic.InUse)
 					.updateValue(powerStateInt);
-				
+
                         break;
 			case "polling":
 				that.log("Check status: polling");
 				this.valveService
 					.getCharacteristic(Characteristic.Active)
-					.on('get', function (callback) 
+					.on('get', function (callback)
 					{ callback(null, that.statusOn) })
-					
+
 					.on('set', this.setPowerStatePolling.bind(this))
-				
+
 			break;
 			default:
 				that.log("Check status: default");
 				this.valveService
 					.getCharacteristic(Characteristic.Active)
 					.on('set', this.setPowerState.bind(this))
-				
+
 			break;
                 }
-		
-		if (this.useTimer == "yes") 
+
+		if (this.useTimer == "yes")
 		{
 			this.valveService.addCharacteristic(Characteristic.SetDuration);
 			this.valveService.addCharacteristic(Characteristic.RemainingDuration);
-			
+
 			// Set initial runtime from config
 			this.valveService.getCharacteristic(Characteristic.SetDuration).setValue(this.defaultTime);
-			
+
 			this.valveService.getCharacteristic(Characteristic.SetDuration)
 				.on('change', this.setDurationTime.bind(this));
-			
+
 			this.valveService.getCharacteristic(Characteristic.RemainingDuration)
 				.on('change', (data) => { console.log("Valve Remaining Duration changed to: " + data.newValue) })
 
 			this.valveService.getCharacteristic(Characteristic.InUse)
 				.on('change', this.setRemainingTime.bind(this));
 		}
-		
-		return [this.valveService];
+
+		return [this.valveService, this.informationService];
 	}
 };


### PR DESCRIPTION
Hi there,

Just some small changes:

- Allow `manufacturer`, `serial` and `model` to be specified in the `config.json` file
- Simplify table with the `config.json` fields & include new fields
- Simple configuration example to go along with the more detailed "Domoticz JSON API" one
- Other small changes to the README

Hopefully you approve of these changes and can merge them into the master branch and push it to `npm`. Feel free to ask questions and make suggestions or changes!

Kind regards,
Tom